### PR TITLE
fix verify tags

### DIFF
--- a/roles/cis/tasks/1/verify/1.7.1.6.yml
+++ b/roles/cis/tasks/1/verify/1.7.1.6.yml
@@ -15,7 +15,9 @@
         msg: "1.7.1.6 failed to verify permissions. expected: 0666. found: {{ issue.stat.mode }}"
       when: issue.stat.mode != "0666"
   tags:
-    - notscored
+    - cis
+    - cis.1
     - cis.1.7
     - cis.1.7.1
     - cis.1.7.1.6
+    - notscored

--- a/roles/cis/tasks/6/verify/6.1.2.yml
+++ b/roles/cis/tasks/6/verify/6.1.2.yml
@@ -15,6 +15,8 @@
         msg: "6.1.2 failed to verify permissions. expected: 0644. found: {{ etcpass.stat.mode }}"
       when: etcpass.stat.mode != "0644"
   tags:
-    - scored
+    - cis
+    - cis.6
     - cis.6.1
     - cis.6.1.2
+    - scored


### PR DESCRIPTION
- issue with verify commands like --tags "cis" -e verify=true not including verify tasks
- fixed by adding necessary tags to verify scripts