### PR TITLE
Do not print unnecessary skipped tests logging

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+display_skipped_hosts = no


### PR DESCRIPTION
This avoids not so interesting test log prints like below, so that test results look more clean:

TASK [cis : fail] **************************************************************
skipping: [/root/testroot]
TASK [cis : fail] **************************************************************
skipping: [/root/testroot]
TASK [cis : fail] **************************************************************
skipping: [/root/testroot]